### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/MakiAno/hyper_snackbar/security/code-scanning/1](https://github.com/MakiAno/hyper_snackbar/security/code-scanning/1)

In general, the fix is to explicitly declare the minimal required `GITHUB_TOKEN` permissions for the workflow or for each job. Since this CI workflow only checks out code and runs analysis/tests locally, it only needs read access to repository contents. We can therefore add `permissions: contents: read` either at the root of the workflow (applies to all jobs) or under the `build` job. To keep the change tightly scoped to the highlighted job, we’ll add the block under `jobs.build`.

Concretely, in `.github/workflows/ci.yml`, under `jobs:`, in the `build:` job definition and before `runs-on: ubuntu-latest`, insert:

```yaml
    permissions:
      contents: read
```

This does not require any imports, methods, or other definitions, and does not change the existing functionality: the CI job will still be able to check out code and run Flutter/Dart commands, while the `GITHUB_TOKEN` will be limited to read-only repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
