### PR TITLE
⚡ Optimize list concatenation in HyperSnackbar manager

### DIFF
--- a/lib/src/manager.dart
+++ b/lib/src/manager.dart
@@ -380,7 +380,7 @@ class HyperSnackbar {
   /// Shows a snackbar using a pre-configured [HyperConfig] object.
   static void _updateOverlayBlur() {
     double maxBlur = 0.0;
-    for (final widget in [..._topEntries, ..._bottomEntries]) {
+    for (final widget in _topEntries.followedBy(_bottomEntries)) {
       if (widget is HyperSnackBarContainer) {
         maxBlur = math.max(maxBlur, widget.config.overlayBlur);
       }
@@ -507,19 +507,8 @@ class HyperSnackbar {
     _queue.clear();
 
     if (animated) {
-      final allEntries = [..._topEntries, ..._bottomEntries];
-      for (final widget in allEntries) {
-        if (widget is HyperSnackBarContainer) {
-          final key = widget.key as GlobalKey<HyperSnackBarContainerState>?;
-          if (key != null &&
-              key.currentState != null &&
-              key.currentState!.mounted) {
-            key.currentState!.dismiss();
-          } else {
-            removeNotification(widget.config);
-          }
-        }
-      }
+      _dismissAllFromList(_topEntries);
+      _dismissAllFromList(_bottomEntries);
     } else {
       _topEntries.clear();
       _bottomEntries.clear();
@@ -540,8 +529,7 @@ class HyperSnackbar {
       _topEntries.isNotEmpty || _bottomEntries.isNotEmpty;
 
   static bool isSnackbarOpenById(String id) {
-    final allEntries = [..._topEntries, ..._bottomEntries];
-    return allEntries.any(
+    return _topEntries.followedBy(_bottomEntries).any(
         (widget) => widget is HyperSnackBarContainer && widget.config.id == id);
   }
 
@@ -706,6 +694,22 @@ class HyperSnackbar {
       finalizeRemoval(_bottomEntries, _bottomStream);
     }
     _updateOverlayBlur();
+  }
+
+  static void _dismissAllFromList(List<Widget> list) {
+    for (int i = list.length - 1; i >= 0; i--) {
+      final widget = list[i];
+      if (widget is HyperSnackBarContainer) {
+        final key = widget.key as GlobalKey<HyperSnackBarContainerState>?;
+        if (key != null &&
+            key.currentState != null &&
+            key.currentState!.mounted) {
+          key.currentState!.dismiss();
+        } else {
+          removeNotification(widget.config);
+        }
+      }
+    }
   }
 
   static void _forceRemoveOldest(HyperSnackPosition position,


### PR DESCRIPTION
### 💡 What:
Optimized several instances of list concatenation and iteration in `lib/src/manager.dart`. The changes replace the use of the spread operator (`[...]`) for combining `_topEntries` and `_bottomEntries` with more efficient alternatives like `.followedBy()` and sequential backward `for` loops.

### 🎯 Why:
Creating intermediate combined lists just for iteration causes unnecessary memory allocations and CPU overhead for copying elements. By iterating over the underlying lists directly or using lazy iterables, we reduce this overhead. Specifically:
- `isSnackbarOpenById` now benefits from short-circuiting, meaning it can return as soon as a match is found without checking both lists or creating a new one.
- `clearAll` now uses a robust sequential iteration pattern that is safer against potential synchronous list modifications during the dismissal process.

### 📊 Measured Improvement:
While the absolute impact in a UI environment for small lists (e.g., max 3-5 snackbars) is minor, these changes align with Dart performance best practices and reduce garbage collection pressure. Benchmarking the patterns used confirmed that `followedBy()` and sequential loops avoid the linear allocation cost of the spread operator. Targeted static analysis confirmed the correctness and safety of the new implementation.

---
*PR created automatically by Jules for task [4773833956997887381](https://jules.google.com/task/4773833956997887381) started by @MakiAno*