### PR TITLE
🔒 [security fix] improve debuggability of overlay entry removal

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -136,10 +136,9 @@ class HomePage extends StatelessWidget {
               color: Colors.teal,
               icon: Icons.style,
               onTap: () {
-                Navigator.of(
-                  context,
-                ).push(
-                    MaterialPageRoute(builder: (_) => const PresetDemoPage()));
+                Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const PresetDemoPage()),
+                );
               },
             ),
 
@@ -152,10 +151,9 @@ class HomePage extends StatelessWidget {
               color: Colors.orange,
               icon: Icons.blur_on,
               onTap: () {
-                Navigator.of(
-                  context,
-                ).push(MaterialPageRoute(
-                    builder: (_) => const GetxLikeDemoPage()));
+                Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const GetxLikeDemoPage()),
+                );
               },
             ),
           ],

--- a/example/lib/pages/getx_like_page.dart
+++ b/example/lib/pages/getx_like_page.dart
@@ -26,10 +26,7 @@ class GetxLikeDemoPage extends StatelessWidget {
                   child: Center(
                     child: Text(
                       '$index',
-                      style: TextStyle(
-                        color: Colors.grey[500],
-                        fontSize: 10,
-                      ),
+                      style: TextStyle(color: Colors.grey[500], fontSize: 10),
                     ),
                   ),
                 );
@@ -89,7 +86,10 @@ class GetxLikeDemoPage extends StatelessWidget {
                         snackPosition: SnackPosition.BOTTOM,
                         overlayBlur: 10.0,
                         margin: const EdgeInsets.only(
-                            bottom: 40, left: 16, right: 16),
+                          bottom: 40,
+                          left: 16,
+                          right: 16,
+                        ),
                         duration: const Duration(seconds: 4),
                         backgroundColor: Colors.redAccent,
                         colorText: Colors.white,
@@ -125,16 +125,19 @@ class GetxLikeDemoPage extends StatelessWidget {
                         duration: const Duration(seconds: 6),
                         backgroundColor: Colors.deepOrange,
                         colorText: Colors.white,
-                        icon: const Icon(Icons.warning_amber_rounded,
-                            color: Colors.white),
+                        icon: const Icon(
+                          Icons.warning_amber_rounded,
+                          color: Colors.white,
+                        ),
                         shouldIconPulse: true,
                         mainButton: TextButton(
                           onPressed: () => HyperSnackbar.clearAll(),
                           child: const Text(
                             'DISMISS',
                             style: TextStyle(
-                                color: Colors.white,
-                                fontWeight: FontWeight.bold),
+                              color: Colors.white,
+                              fontWeight: FontWeight.bold,
+                            ),
                           ),
                         ),
                         margin: const EdgeInsets.all(24),
@@ -144,7 +147,7 @@ class GetxLikeDemoPage extends StatelessWidget {
                             color: Colors.deepOrange.withAlpha(150),
                             blurRadius: 20,
                             offset: const Offset(0, 10),
-                          )
+                          ),
                         ],
                         onTap: () {
                           debugPrint('Snackbar Tapped!');

--- a/example/lib/pages/playground_page.dart
+++ b/example/lib/pages/playground_page.dart
@@ -199,8 +199,9 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
 
     Color? progressColor;
     if (width == 0) {
-      progressColor =
-          isLightBg ? Colors.black.withAlpha(25) : Colors.white.withAlpha(38);
+      progressColor = isLightBg
+          ? Colors.black.withAlpha(25)
+          : Colors.white.withAlpha(38);
     } else if (width != null && width > 0) {
       progressColor = Colors.redAccent;
     }
@@ -217,8 +218,9 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
       }
     }
 
-    EdgeInsets effectiveMargin =
-        _useMargin ? const EdgeInsets.all(12) : EdgeInsets.zero;
+    EdgeInsets effectiveMargin = _useMargin
+        ? const EdgeInsets.all(12)
+        : EdgeInsets.zero;
 
     final targetContext = _innerScaffoldKey.currentContext;
 
@@ -231,10 +233,7 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
         textColor: contentColor,
         icon: _iconMode == _IconMode.none
             ? null
-            : Icon(
-                _getIconForColor(_selectedColor),
-                color: contentColor,
-              ),
+            : Icon(_getIconForColor(_selectedColor), color: contentColor),
         useAdaptiveLoader: _iconMode == _IconMode.loader,
         borderRadius: _borderRadius,
         elevation: _elevation,
@@ -263,8 +262,9 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
         action: _showAction
             ? HyperSnackAction(
                 label: 'UNDO',
-                textColor:
-                    isLightBg ? Colors.blue.shade700 : Colors.amberAccent,
+                textColor: isLightBg
+                    ? Colors.blue.shade700
+                    : Colors.amberAccent,
                 onPressed: () {
                   _showUndoFeedback();
                 },
@@ -279,8 +279,9 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
   void _showUndoFeedback() {
     final targetContext = _innerScaffoldKey.currentContext;
     if (targetContext != null) {
-      EdgeInsets margin =
-          _useMargin ? const EdgeInsets.all(12) : EdgeInsets.zero;
+      EdgeInsets margin = _useMargin
+          ? const EdgeInsets.all(12)
+          : EdgeInsets.zero;
 
       HyperSnackbar.show(
         context: targetContext,
@@ -724,9 +725,10 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
                       visualDensity: VisualDensity.compact,
                       tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                       backgroundColor: WidgetStateProperty.resolveWith(
-                          (states) => states.contains(WidgetState.selected)
-                              ? Colors.cyan.withAlpha(77)
-                              : Colors.transparent),
+                        (states) => states.contains(WidgetState.selected)
+                            ? Colors.cyan.withAlpha(77)
+                            : Colors.transparent,
+                      ),
                       foregroundColor: WidgetStateProperty.all(Colors.white),
                     ),
                     segments: const [
@@ -1306,10 +1308,12 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
       if (isLightBg) {
         sb.writeln('  textColor: Colors.black87,');
         sb.writeln(
-            '  icon: Icon(Icons.${_getIconName()}, color: Colors.black87),');
+          '  icon: Icon(Icons.${_getIconName()}, color: Colors.black87),',
+        );
       } else {
         sb.writeln(
-            '  icon: Icon(Icons.${_getIconName()}, color: Colors.white),');
+          '  icon: Icon(Icons.${_getIconName()}, color: Colors.white),',
+        );
       }
     } else if (_iconMode == _IconMode.loader) {
       sb.writeln('  useAdaptiveLoader: true,');

--- a/example/lib/pages/preset_demo_page.dart
+++ b/example/lib/pages/preset_demo_page.dart
@@ -180,7 +180,8 @@ class _PresetDemoPageState extends State<PresetDemoPage> {
 
               const SizedBox(height: 20),
               const _SectionHeader(
-                  text: "6. Max Width & Alignment (Override Brand Preset)"),
+                text: "6. Max Width & Alignment (Override Brand Preset)",
+              ),
               Row(
                 children: [
                   // alignment: left

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -20,14 +20,7 @@ enum HyperSnackDisplayMode {
 }
 
 /// Defines the entrance and exit animation styles.
-enum HyperSnackAnimationType {
-  top,
-  bottom,
-  left,
-  right,
-  fade,
-  scale,
-}
+enum HyperSnackAnimationType { top, bottom, left, right, fade, scale }
 
 /// Represents an action button displayed within the snackbar.
 class HyperSnackAction {

--- a/lib/src/container.dart
+++ b/lib/src/container.dart
@@ -45,8 +45,10 @@ class HyperSnackBarContainerState extends State<HyperSnackBarContainer>
       duration: config.enterAnimationDuration,
     );
 
-    _animation =
-        CurvedAnimation(parent: _animationController, curve: config.enterCurve);
+    _animation = CurvedAnimation(
+      parent: _animationController,
+      curve: config.enterCurve,
+    );
 
     // 2. Controller for display duration management
     _durationController = AnimationController(
@@ -212,23 +214,22 @@ class HyperSnackBarContainerState extends State<HyperSnackBarContainer>
       case HyperSnackAnimationType.scale:
         return ScaleTransition(
           scale: Tween<double>(begin: 0.6, end: 1.0).animate(_animation),
-          child: FadeTransition(
-            opacity: _animation,
-            child: child,
-          ),
+          child: FadeTransition(opacity: _animation, child: child),
         );
       case HyperSnackAnimationType.left:
         return SlideTransition(
-          position:
-              Tween<Offset>(begin: const Offset(-1.0, 0.0), end: Offset.zero)
-                  .animate(_animation),
+          position: Tween<Offset>(
+            begin: const Offset(-1.0, 0.0),
+            end: Offset.zero,
+          ).animate(_animation),
           child: child,
         );
       case HyperSnackAnimationType.right:
         return SlideTransition(
-          position:
-              Tween<Offset>(begin: const Offset(1.0, 0.0), end: Offset.zero)
-                  .animate(_animation),
+          position: Tween<Offset>(
+            begin: const Offset(1.0, 0.0),
+            end: Offset.zero,
+          ).animate(_animation),
           child: child,
         );
       case HyperSnackAnimationType.top:
@@ -249,8 +250,10 @@ class HyperSnackBarContainerState extends State<HyperSnackBarContainer>
   }
 
   Widget _applyExitAnimation(Widget child) {
-    final exitAnim =
-        CurvedAnimation(parent: _animationController, curve: config.exitCurve);
+    final exitAnim = CurvedAnimation(
+      parent: _animationController,
+      curve: config.exitCurve,
+    );
     switch (config.exitAnimationType) {
       case HyperSnackAnimationType.scale:
         return ScaleTransition(
@@ -262,21 +265,25 @@ class HyperSnackBarContainerState extends State<HyperSnackBarContainer>
         );
       case HyperSnackAnimationType.left:
         return SlideTransition(
-          position:
-              Tween<Offset>(begin: Offset.zero, end: const Offset(-1.0, 0.0))
-                  .animate(exitAnim),
+          position: Tween<Offset>(
+            begin: Offset.zero,
+            end: const Offset(-1.0, 0.0),
+          ).animate(exitAnim),
           child: FadeTransition(
-              opacity: Tween<double>(begin: 1.0, end: 0.0).animate(exitAnim),
-              child: child),
+            opacity: Tween<double>(begin: 1.0, end: 0.0).animate(exitAnim),
+            child: child,
+          ),
         );
       case HyperSnackAnimationType.right:
         return SlideTransition(
-          position:
-              Tween<Offset>(begin: Offset.zero, end: const Offset(1.0, 0.0))
-                  .animate(exitAnim),
+          position: Tween<Offset>(
+            begin: Offset.zero,
+            end: const Offset(1.0, 0.0),
+          ).animate(exitAnim),
           child: FadeTransition(
-              opacity: Tween<double>(begin: 1.0, end: 0.0).animate(exitAnim),
-              child: child),
+            opacity: Tween<double>(begin: 1.0, end: 0.0).animate(exitAnim),
+            child: child,
+          ),
         );
       case HyperSnackAnimationType.top:
       case HyperSnackAnimationType.bottom:
@@ -284,16 +291,18 @@ class HyperSnackBarContainerState extends State<HyperSnackBarContainer>
           sizeFactor: Tween<double>(begin: 1.0, end: 0.0).animate(exitAnim),
           axisAlignment:
               (config.exitAnimationType == HyperSnackAnimationType.top)
-                  ? -1.0
-                  : 1.0,
+              ? -1.0
+              : 1.0,
           child: FadeTransition(
-              opacity: Tween<double>(begin: 1.0, end: 0.0).animate(exitAnim),
-              child: child),
+            opacity: Tween<double>(begin: 1.0, end: 0.0).animate(exitAnim),
+            child: child,
+          ),
         );
       case HyperSnackAnimationType.fade:
         return FadeTransition(
-            opacity: Tween<double>(begin: 1.0, end: 0.0).animate(exitAnim),
-            child: child);
+          opacity: Tween<double>(begin: 1.0, end: 0.0).animate(exitAnim),
+          child: child,
+        );
     }
   }
 }

--- a/lib/src/manager.dart
+++ b/lib/src/manager.dart
@@ -54,8 +54,10 @@ class HyperSnackbar {
     TextStyle? messageStyle,
     BoxBorder? border,
     EdgeInsetsGeometry margin = EdgeInsets.zero,
-    EdgeInsetsGeometry padding =
-        const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+    EdgeInsetsGeometry padding = const EdgeInsets.symmetric(
+      horizontal: 16,
+      vertical: 12,
+    ),
     Color? backgroundColor,
     Color? textColor,
     double borderRadius = 12.0,
@@ -121,10 +123,12 @@ class HyperSnackbar {
     final effectiveExitCurve = reverseAnimationCurve ?? exitCurve;
 
     // Resolve Animation Duration (Specific > Unified > Default)
-    final effectiveEnterDuration = enterAnimationDuration ??
+    final effectiveEnterDuration =
+        enterAnimationDuration ??
         animationDuration ??
         const Duration(milliseconds: 300);
-    final effectiveExitDuration = exitAnimationDuration ??
+    final effectiveExitDuration =
+        exitAnimationDuration ??
         animationDuration ??
         const Duration(milliseconds: 500);
 
@@ -138,18 +142,19 @@ class HyperSnackbar {
     Widget? finalContent = effectiveContent;
     if (titleText != null || messageText != null) {
       finalContent = Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (titleText != null) titleText,
-            if (titleText != null && messageText != null)
-              const SizedBox(height: 4),
-            if (messageText != null) messageText,
-            if (effectiveContent != null) ...[
-              const SizedBox(height: 8),
-              effectiveContent
-            ]
-          ]);
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (titleText != null) titleText,
+          if (titleText != null && messageText != null)
+            const SizedBox(height: 4),
+          if (messageText != null) messageText,
+          if (effectiveContent != null) ...[
+            const SizedBox(height: 8),
+            effectiveContent,
+          ],
+        ],
+      );
     }
 
     return HyperConfig(
@@ -314,18 +319,19 @@ class HyperSnackbar {
     Widget? finalContent = effectiveContent;
     if (titleText != null || messageText != null) {
       finalContent = Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (titleText != null) titleText,
-            if (titleText != null && messageText != null)
-              const SizedBox(height: 4),
-            if (messageText != null) messageText,
-            if (effectiveContent != null) ...[
-              const SizedBox(height: 8),
-              effectiveContent
-            ]
-          ]);
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (titleText != null) titleText,
+          if (titleText != null && messageText != null)
+            const SizedBox(height: 4),
+          if (messageText != null) messageText,
+          if (effectiveContent != null) ...[
+            const SizedBox(height: 8),
+            effectiveContent,
+          ],
+        ],
+      );
     }
 
     final config = baseConfig.copyWith(
@@ -529,7 +535,9 @@ class HyperSnackbar {
       if (_overlayEntry != null) {
         try {
           _overlayEntry?.remove();
-        } catch (_) {}
+        } catch (e) {
+          debugPrint('HyperSnackbar: Error removing overlay entry: $e');
+        }
         _overlayEntry = null;
         _isOverlayMounted = false;
       }
@@ -542,7 +550,8 @@ class HyperSnackbar {
   static bool isSnackbarOpenById(String id) {
     final allEntries = [..._topEntries, ..._bottomEntries];
     return allEntries.any(
-        (widget) => widget is HyperSnackBarContainer && widget.config.id == id);
+      (widget) => widget is HyperSnackBarContainer && widget.config.id == id,
+    );
   }
 
   // ===========================================================================
@@ -662,9 +671,13 @@ class HyperSnackbar {
   // ===========================================================================
 
   static bool _tryUpdate(
-      HyperConfig newConfig, List<Widget> list, StreamController stream) {
+    HyperConfig newConfig,
+    List<Widget> list,
+    StreamController stream,
+  ) {
     final index = list.indexWhere(
-        (w) => (w is HyperSnackBarContainer) && w.config.id == newConfig.id);
+      (w) => (w is HyperSnackBarContainer) && w.config.id == newConfig.id,
+    );
     if (index != -1) {
       final oldWidget = list[index] as HyperSnackBarContainer;
       final key = oldWidget.key as GlobalKey<HyperSnackBarContainerState>;
@@ -708,10 +721,13 @@ class HyperSnackbar {
     _updateOverlayBlur();
   }
 
-  static void _forceRemoveOldest(HyperSnackPosition position,
-      {bool newestOnTop = true}) {
-    final targetList =
-        (position == HyperSnackPosition.top) ? _topEntries : _bottomEntries;
+  static void _forceRemoveOldest(
+    HyperSnackPosition position, {
+    bool newestOnTop = true,
+  }) {
+    final targetList = (position == HyperSnackPosition.top)
+        ? _topEntries
+        : _bottomEntries;
     if (targetList.isEmpty) return;
 
     final oldestWidget = newestOnTop ? targetList.last : targetList.first;
@@ -722,7 +738,9 @@ class HyperSnackbar {
   }
 
   static void _mountOverlayIfNeeded(
-      BuildContext? context, bool useLocalOverlay) {
+    BuildContext? context,
+    bool useLocalOverlay,
+  ) {
     // 1. Identify the target OverlayState.
     OverlayState? targetOverlay;
     if (context != null) {
@@ -744,7 +762,9 @@ class HyperSnackbar {
     if (_isOverlayMounted) {
       try {
         _overlayEntry?.remove();
-      } catch (_) {}
+      } catch (e) {
+        debugPrint('HyperSnackbar: Error removing overlay entry: $e');
+      }
       _overlayEntry = null;
       _isOverlayMounted = false;
       _currentOverlayState = null;
@@ -783,7 +803,9 @@ class HyperSnackbar {
     if (_overlayEntry != null) {
       try {
         _overlayEntry?.remove();
-      } catch (_) {}
+      } catch (e) {
+        debugPrint('HyperSnackbar: Error removing overlay entry: $e');
+      }
       _overlayEntry = null;
     }
 
@@ -851,7 +873,9 @@ class _HyperOverlayManager extends StatelessWidget {
               stream: topStream,
               initialData: initialTopData,
               builder: (context, s) => Column(
-                  mainAxisSize: MainAxisSize.min, children: s.data ?? []),
+                mainAxisSize: MainAxisSize.min,
+                children: s.data ?? [],
+              ),
             ),
           ),
         ),
@@ -865,7 +889,9 @@ class _HyperOverlayManager extends StatelessWidget {
               stream: bottomStream,
               initialData: initialBottomData,
               builder: (context, s) => Column(
-                  mainAxisSize: MainAxisSize.min, children: s.data ?? []),
+                mainAxisSize: MainAxisSize.min,
+                children: s.data ?? [],
+              ),
             ),
           ),
         ),

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -58,11 +58,13 @@ class _HyperSnackBarContentState extends State<HyperSnackBarContent> {
     // Get padding from config
     final EdgeInsetsGeometry basePadding = config.padding;
     final double leftPad = basePadding is EdgeInsets ? basePadding.left : 16.0;
-    final double rightPad =
-        basePadding is EdgeInsets ? basePadding.right : 16.0;
+    final double rightPad = basePadding is EdgeInsets
+        ? basePadding.right
+        : 16.0;
     final double topPad = basePadding is EdgeInsets ? basePadding.top : 12.0;
-    final double bottomPad =
-        basePadding is EdgeInsets ? basePadding.bottom : 12.0;
+    final double bottomPad = basePadding is EdgeInsets
+        ? basePadding.bottom
+        : 12.0;
 
     // Check for the presence of each section
     final bool hasMessage = config.message != null;
@@ -104,7 +106,8 @@ class _HyperSnackBarContentState extends State<HyperSnackBarContent> {
         }
       }
 
-      final isCupertino = Theme.of(context).platform == TargetPlatform.iOS ||
+      final isCupertino =
+          Theme.of(context).platform == TargetPlatform.iOS ||
           Theme.of(context).platform == TargetPlatform.macOS;
 
       // --- Loader ---
@@ -151,14 +154,15 @@ class _HyperSnackBarContentState extends State<HyperSnackBarContent> {
         color: bgColor,
         borderRadius: BorderRadius.circular(config.borderRadius),
         border: config.border,
-        boxShadow: config.boxShadows ??
+        boxShadow:
+            config.boxShadows ??
             (config.elevation > 0
                 ? [
                     BoxShadow(
                       color: Colors.black.withAlpha(50),
                       blurRadius: config.elevation,
                       offset: Offset(0, config.elevation / 2),
-                    )
+                    ),
                   ]
                 : null),
       ),
@@ -194,9 +198,7 @@ class _HyperSnackBarContentState extends State<HyperSnackBarContent> {
                 onTap: config.onTap,
                 borderRadius: BorderRadius.circular(config.borderRadius),
                 child: ConstrainedBox(
-                  constraints: BoxConstraints(
-                    maxHeight: screenHeight * 0.8,
-                  ),
+                  constraints: BoxConstraints(maxHeight: screenHeight * 0.8),
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -225,7 +227,8 @@ class _HyperSnackBarContentState extends State<HyperSnackBarContent> {
                                 Expanded(
                                   child: Text(
                                     config.title!,
-                                    style: config.titleStyle ??
+                                    style:
+                                        config.titleStyle ??
                                         TextStyle(
                                           color: txtColor,
                                           fontWeight: FontWeight.bold,
@@ -242,8 +245,11 @@ class _HyperSnackBarContentState extends State<HyperSnackBarContent> {
                                 const SizedBox(width: 8),
                                 GestureDetector(
                                   onTap: widget.onDismiss,
-                                  child: Icon(Icons.close,
-                                      size: 20, color: txtColor.withAlpha(153)),
+                                  child: Icon(
+                                    Icons.close,
+                                    size: 20,
+                                    color: txtColor.withAlpha(153),
+                                  ),
                                 ),
                               ],
                             ],
@@ -279,7 +285,8 @@ class _HyperSnackBarContentState extends State<HyperSnackBarContent> {
                                 thumbVisibility: true,
                                 child: SingleChildScrollView(
                                   controller: _scrollController,
-                                  physics: (config.scrollable ||
+                                  physics:
+                                      (config.scrollable ||
                                           config.maxLines == null)
                                       ? const BouncingScrollPhysics()
                                       : const NeverScrollableScrollPhysics(),
@@ -298,16 +305,19 @@ class _HyperSnackBarContentState extends State<HyperSnackBarContent> {
                                           : Alignment.topLeft,
                                       child: Text(
                                         displayMessage, // Use stabilized message
-                                        style: config.messageStyle ??
+                                        style:
+                                            config.messageStyle ??
                                             TextStyle(
                                               color: txtColor.withAlpha(230),
                                               fontSize: 14,
                                             ),
-                                        maxLines: (config.scrollable ||
+                                        maxLines:
+                                            (config.scrollable ||
                                                 config.maxLines == null)
                                             ? null
                                             : config.maxLines,
-                                        overflow: (config.scrollable ||
+                                        overflow:
+                                            (config.scrollable ||
                                                 config.maxLines == null)
                                             ? TextOverflow.visible
                                             : TextOverflow.ellipsis,
@@ -352,13 +362,15 @@ class _HyperSnackBarContentState extends State<HyperSnackBarContent> {
                                       style: TextButton.styleFrom(
                                         foregroundColor:
                                             config.action!.textColor ??
-                                                Theme.of(context)
-                                                    .colorScheme
-                                                    .primary,
+                                            Theme.of(
+                                              context,
+                                            ).colorScheme.primary,
                                         backgroundColor:
                                             config.action!.backgroundColor,
                                         padding: const EdgeInsets.symmetric(
-                                            horizontal: 8, vertical: 4),
+                                          horizontal: 8,
+                                          vertical: 4,
+                                        ),
                                         minimumSize: Size.zero,
                                         tapTargetSize:
                                             MaterialTapTargetSize.shrinkWrap,
@@ -366,7 +378,8 @@ class _HyperSnackBarContentState extends State<HyperSnackBarContent> {
                                       child: Text(
                                         config.action!.label,
                                         style: const TextStyle(
-                                            fontWeight: FontWeight.bold),
+                                          fontWeight: FontWeight.bold,
+                                        ),
                                       ),
                                     ),
                                   ],
@@ -394,8 +407,9 @@ class _HyperSnackBarContentState extends State<HyperSnackBarContent> {
                       return LinearProgressIndicator(
                         value: widget.durationAnimation!.value,
                         backgroundColor: Colors.transparent,
-                        valueColor:
-                            AlwaysStoppedAnimation<Color>(progressColor),
+                        valueColor: AlwaysStoppedAnimation<Color>(
+                          progressColor,
+                        ),
                         minHeight: config.progressBarWidth,
                         borderRadius: BorderRadius.zero,
                       );
@@ -413,7 +427,9 @@ class _HyperSnackBarContentState extends State<HyperSnackBarContent> {
         borderRadius: BorderRadius.circular(config.borderRadius),
         child: BackdropFilter(
           filter: ui.ImageFilter.blur(
-              sigmaX: config.barBlur, sigmaY: config.barBlur),
+            sigmaX: config.barBlur,
+            sigmaY: config.barBlur,
+          ),
           child: materialContent,
         ),
       );
@@ -426,10 +442,7 @@ class _HyperSnackBarContentState extends State<HyperSnackBarContent> {
           // Apply maxWidth if specified, otherwise it's infinite (existing behavior)
           maxWidth: config.maxWidth ?? double.infinity,
         ),
-        child: Container(
-          margin: config.margin,
-          child: materialContent,
-        ),
+        child: Container(margin: config.margin, child: materialContent),
       ),
     );
   }

--- a/test/coverage_booster_test.dart
+++ b/test/coverage_booster_test.dart
@@ -60,8 +60,9 @@ void main() {
     });
 
     // 3. Update by ID (_tryUpdate) and Dismiss by ID (dismissById)
-    testWidgets('Update and Dismiss by ID coverage',
-        (WidgetTester tester) async {
+    testWidgets('Update and Dismiss by ID coverage', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestApp(Container()));
 
       const String testId = 'unique_id';
@@ -84,8 +85,9 @@ void main() {
     });
 
     // 4. Coverage for using Widgets for title/message
-    testWidgets('Widget title and message coverage',
-        (WidgetTester tester) async {
+    testWidgets('Widget title and message coverage', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestApp(Container()));
 
       HyperSnackbar.show(
@@ -101,14 +103,18 @@ void main() {
     });
 
     // 5. Timer pause and resume by scrolling
-    testWidgets('Scroll pause and resume timer coverage',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(createTestApp(
-        ListView.builder(
-          itemCount: 100,
-          itemBuilder: (context, index) => ListTile(title: Text('Item $index')),
+    testWidgets('Scroll pause and resume timer coverage', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        createTestApp(
+          ListView.builder(
+            itemCount: 100,
+            itemBuilder: (context, index) =>
+                ListTile(title: Text('Item $index')),
+          ),
         ),
-      ));
+      );
 
       HyperSnackbar.show(
         title: 'Scroll Test',

--- a/test/gorouter_compatibility_test.dart
+++ b/test/gorouter_compatibility_test.dart
@@ -5,8 +5,9 @@ import 'package:go_router/go_router.dart';
 import 'package:hyper_snackbar/hyper_snackbar.dart';
 
 void main() {
-  testWidgets('GoRouter transition does not crash HyperSnackbar',
-      (WidgetTester tester) async {
+  testWidgets('GoRouter transition does not crash HyperSnackbar', (
+    WidgetTester tester,
+  ) async {
     // 1. Launch the app (using the router defined in this file)
     await tester.pumpWidget(_createTestApp());
 
@@ -47,7 +48,8 @@ Widget _createTestApp() {
                 );
               },
               child: const Text(
-                  'Show Snackbar'), // The text that `find.text()` is looking for.
+                'Show Snackbar',
+              ), // The text that `find.text()` is looking for.
             ),
           ),
         ),
@@ -55,7 +57,5 @@ Widget _createTestApp() {
     ],
   );
 
-  return MaterialApp.router(
-    routerConfig: router,
-  );
+  return MaterialApp.router(routerConfig: router);
 }

--- a/test/hyper_snackbar_blur_test.dart
+++ b/test/hyper_snackbar_blur_test.dart
@@ -36,8 +36,9 @@ void main() {
     await tester.pump(const Duration(milliseconds: 500)); // exit animation
   });
 
-  testWidgets('overlayBlur creates a full-screen BackdropFilter',
-      (WidgetTester tester) async {
+  testWidgets('overlayBlur creates a full-screen BackdropFilter', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(createTestApp(Container()));
 
     HyperSnackbar.show(
@@ -57,8 +58,9 @@ void main() {
 
     // wait for it to dismiss to not leak animations
     await tester.pump(const Duration(seconds: 1)); // wait for display
-    await tester
-        .pumpAndSettle(const Duration(milliseconds: 500)); // exit animation
+    await tester.pumpAndSettle(
+      const Duration(milliseconds: 500),
+    ); // exit animation
   });
 
   testWidgets('GetX aliases map correctly', (WidgetTester tester) async {
@@ -80,9 +82,7 @@ void main() {
     expect(config.position, HyperSnackPosition.bottom);
     expect(config.textColor, Colors.red);
 
-    final configTop = HyperSnackbar.preset(
-      snackPosition: SnackPosition.TOP,
-    );
+    final configTop = HyperSnackbar.preset(snackPosition: SnackPosition.TOP);
     expect(configTop.position, HyperSnackPosition.top);
   });
 }

--- a/test/hyper_snackbar_coverage_test.dart
+++ b/test/hyper_snackbar_coverage_test.dart
@@ -9,17 +9,18 @@ void main() {
     });
 
     // 1. Coverage for SnackPosition.BOTTOM mapping logic (near L112-114)
-    testWidgets('SnackPosition.BOTTOM mapping coverage',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(MaterialApp(
-        navigatorKey: HyperSnackbar.navigatorKey,
-        home: const Scaffold(),
-      ));
+    testWidgets('SnackPosition.BOTTOM mapping coverage', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: HyperSnackbar.navigatorKey,
+          home: const Scaffold(),
+        ),
+      );
 
       // Verify mapping in preset
-      final config = HyperSnackbar.preset(
-        snackPosition: SnackPosition.BOTTOM,
-      );
+      final config = HyperSnackbar.preset(snackPosition: SnackPosition.BOTTOM);
       expect(config.position, HyperSnackPosition.bottom);
 
       // Verify mapping via show
@@ -47,26 +48,29 @@ void main() {
     });
 
     // 3. Coverage for BuildContext extension methods (near L877-1005)
-    testWidgets('Extension method context.showHyperSnackbar coverage',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(MaterialApp(
-        navigatorKey: HyperSnackbar.navigatorKey,
-        home: Scaffold(
-          body: Builder(
-            builder: (context) => Center(
-              child: ElevatedButton(
-                onPressed: () {
-                  context.showHyperSnackbar(
-                    title: 'Extension Title',
-                    message: 'Extension Message',
-                  );
-                },
-                child: const Text('Show'),
+    testWidgets('Extension method context.showHyperSnackbar coverage', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: HyperSnackbar.navigatorKey,
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    context.showHyperSnackbar(
+                      title: 'Extension Title',
+                      message: 'Extension Message',
+                    );
+                  },
+                  child: const Text('Show'),
+                ),
               ),
             ),
           ),
         ),
-      ));
+      );
 
       await tester.tap(find.text('Show'));
       await tester.pump();

--- a/test/hyper_snackbar_test.dart
+++ b/test/hyper_snackbar_test.dart
@@ -22,8 +22,9 @@ void main() {
       );
     }
 
-    testWidgets('isSnackbarOpen reflects the visibility of a snackbar',
-        (WidgetTester tester) async {
+    testWidgets('isSnackbarOpen reflects the visibility of a snackbar', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestApp(Container()));
       expect(HyperSnackbar.isSnackbarOpen, isFalse);
 
@@ -41,8 +42,9 @@ void main() {
       expect(find.text('Test'), findsNothing);
     });
 
-    testWidgets('Queue mode displays snackbars sequentially',
-        (WidgetTester tester) async {
+    testWidgets('Queue mode displays snackbars sequentially', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestApp(Container()));
 
       const display = Duration(milliseconds: 500);
@@ -79,8 +81,9 @@ void main() {
       await tester.pumpAndSettle();
     });
 
-    testWidgets('clearAll clears the queue and screen',
-        (WidgetTester tester) async {
+    testWidgets('clearAll clears the queue and screen', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestApp(Container()));
 
       for (var i = 1; i <= 3; i++) {
@@ -104,8 +107,9 @@ void main() {
       expect(HyperSnackbar.isSnackbarOpen, isFalse);
     });
 
-    testWidgets('Queue mode handles multiple items correctly',
-        (WidgetTester tester) async {
+    testWidgets('Queue mode handles multiple items correctly', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestApp(Container()));
 
       const display = Duration(milliseconds: 500);
@@ -157,24 +161,27 @@ void main() {
 
     // --- New tests added below ---
 
-    testWidgets('Test whether swiping can dismiss the SnackBar',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(MaterialApp(
-        home: Scaffold(
-          body: Builder(
-            builder: (context) => TextButton(
-              onPressed: () {
-                HyperSnackbar.show(
-                  title: 'Swipe to dismiss', // Title
-                  enableSwipe: true,
-                  context: context,
-                );
-              },
-              child: const Text('Show'),
+    testWidgets('Test whether swiping can dismiss the SnackBar', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () {
+                  HyperSnackbar.show(
+                    title: 'Swipe to dismiss', // Title
+                    enableSwipe: true,
+                    context: context,
+                  );
+                },
+                child: const Text('Show'),
+              ),
             ),
           ),
         ),
-      ));
+      );
 
       await tester.tap(find.text('Show'));
       await tester.pump();
@@ -192,8 +199,9 @@ void main() {
       expect(find.text('Swipe to dismiss'), findsNothing);
     });
 
-    testWidgets('maxVisibleCount limit test: UI overlap fixed version',
-        (WidgetTester tester) async {
+    testWidgets('maxVisibleCount limit test: UI overlap fixed version', (
+      WidgetTester tester,
+    ) async {
       // Thanks to setUp, resetForTest() runs automatically here.
 
       await tester.pumpWidget(
@@ -214,8 +222,9 @@ void main() {
                         message: 'Message',
                         maxVisibleCount: 2,
                         displayDuration: const Duration(seconds: 20),
-                        enterAnimationDuration:
-                            const Duration(milliseconds: 500),
+                        enterAnimationDuration: const Duration(
+                          milliseconds: 500,
+                        ),
                       );
                     },
                     child: const Text('PUSH ME'),
@@ -249,27 +258,30 @@ void main() {
       await tester.pumpAndSettle();
     });
 
-// -------------------------------------------------------------------------
+    // -------------------------------------------------------------------------
     // Situation 1: Template creation (Can it be instantiated without a title?)
     // -------------------------------------------------------------------------
-    test('Should instantiate HyperConfig without a title (Template Pattern)',
-        () {
-      // Previously caused an error because it was required
-      const errorTemplate = HyperConfig(
-        backgroundColor: Colors.red,
-        borderRadius: 8.0,
-        icon: Icon(Icons.error),
-      );
+    test(
+      'Should instantiate HyperConfig without a title (Template Pattern)',
+      () {
+        // Previously caused an error because it was required
+        const errorTemplate = HyperConfig(
+          backgroundColor: Colors.red,
+          borderRadius: 8.0,
+          icon: Icon(Icons.error),
+        );
 
-      expect(errorTemplate.title, isNull);
-      expect(errorTemplate.backgroundColor, Colors.red);
-    });
+        expect(errorTemplate.title, isNull);
+        expect(errorTemplate.backgroundColor, Colors.red);
+      },
+    );
 
     // ------------------------------------------------------ -------------------
     // Situation 2: Injecting and displaying the title using a template
     // -------------------------------------------------------------------------
-    testWidgets('Should display injected title when using template',
-        (WidgetTester tester) async {
+    testWidgets('Should display injected title when using template', (
+      WidgetTester tester,
+    ) async {
       // App setup
       await tester.pumpWidget(
         MaterialApp(
@@ -298,9 +310,13 @@ void main() {
 
       // 3. Verification
       expect(
-          find.text('Upload Complete'), findsOneWidget); // Title is displayed
-      expect(find.text('File has been saved.'),
-          findsOneWidget); // Message is also OK
+        find.text('Upload Complete'),
+        findsOneWidget,
+      ); // Title is displayed
+      expect(
+        find.text('File has been saved.'),
+        findsOneWidget,
+      ); // Message is also OK
       expect(find.byIcon(Icons.check), findsOneWidget); // Template icon is OK
 
       await tester.pumpAndSettle();
@@ -309,8 +325,9 @@ void main() {
     // ---------------------------------------------------------- ---------------
     // Scenario 3: Safety Check when title is completely null
     // ---------------------------------------------------------- ---------------
-    testWidgets('Should not crash when title is null',
-        (WidgetTester tester) async {
+    testWidgets('Should not crash when title is null', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           navigatorKey: HyperSnackbar.navigatorKey,
@@ -319,9 +336,7 @@ void main() {
       );
 
       // 1. No title configuration
-      const noTitleConfig = HyperConfig(
-        message: 'Message Only Notification',
-      );
+      const noTitleConfig = HyperConfig(message: 'Message Only Notification');
 
       // 2. Display as-is (to verify Text(config.title ?? '') in widget.dart works)
       HyperSnackbar.showFromConfig(noTitleConfig);
@@ -337,33 +352,37 @@ void main() {
       await tester.pumpAndSettle();
     });
 
-    testWidgets('displayDuration controls how long the snackbar stays visible',
-        (WidgetTester tester) async {
-      await tester.pumpWidget(createTestApp(Container()));
+    testWidgets(
+      'displayDuration controls how long the snackbar stays visible',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(createTestApp(Container()));
 
-      HyperSnackbar.show(
-        title: 'Duration Test',
-        displayDuration: const Duration(seconds: 2),
-      );
+        HyperSnackbar.show(
+          title: 'Duration Test',
+          displayDuration: const Duration(seconds: 2),
+        );
 
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100)); // animation in
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100)); // animation in
 
-      expect(find.text('Duration Test'), findsOneWidget);
+        expect(find.text('Duration Test'), findsOneWidget);
 
-      await tester.pump(const Duration(seconds: 1)); // wait 1s
+        await tester.pump(const Duration(seconds: 1)); // wait 1s
 
-      expect(find.text('Duration Test'), findsOneWidget); // still there
+        expect(find.text('Duration Test'), findsOneWidget); // still there
 
-      await tester.pump(const Duration(seconds: 1)); // wait another 1s
-      await tester
-          .pump(const Duration(milliseconds: 600)); // wait for exit animation
+        await tester.pump(const Duration(seconds: 1)); // wait another 1s
+        await tester.pump(
+          const Duration(milliseconds: 600),
+        ); // wait for exit animation
 
-      expect(find.text('Duration Test'), findsNothing); // should be gone
-    });
+        expect(find.text('Duration Test'), findsNothing); // should be gone
+      },
+    );
 
-    testWidgets('Colors are applied correctly to background and text',
-        (WidgetTester tester) async {
+    testWidgets('Colors are applied correctly to background and text', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestApp(Container()));
 
       const bgColor = Colors.purple;
@@ -382,7 +401,9 @@ void main() {
       // In the implementation, color is now handled by Container decoration
       final containerFinder = find
           .ancestor(
-              of: find.byType(Material).last, matching: find.byType(Container))
+            of: find.byType(Material).last,
+            matching: find.byType(Container),
+          )
           .first;
       final containerWidget = tester.widget<Container>(containerFinder);
       expect((containerWidget.decoration as BoxDecoration).color, bgColor);
@@ -398,8 +419,9 @@ void main() {
       await tester.pumpAndSettle();
     });
 
-    testWidgets('Action button triggers callback and auto-dismisses',
-        (WidgetTester tester) async {
+    testWidgets('Action button triggers callback and auto-dismisses', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestApp(Container()));
 
       bool actionTriggered = false;
@@ -427,13 +449,15 @@ void main() {
 
       expect(actionTriggered, isTrue);
 
-      await tester
-          .pump(const Duration(milliseconds: 600)); // wait for exit animation
+      await tester.pump(
+        const Duration(milliseconds: 600),
+      ); // wait for exit animation
       expect(find.text('Action Test'), findsNothing); // it should be dismissed
     });
 
-    testWidgets('Action button triggers callback without auto-dismissing',
-        (WidgetTester tester) async {
+    testWidgets('Action button triggers callback without auto-dismissing', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestApp(Container()));
 
       bool actionTriggered = false;
@@ -461,16 +485,20 @@ void main() {
 
       expect(actionTriggered, isTrue);
 
-      await tester
-          .pump(const Duration(milliseconds: 600)); // wait for exit animation
-      expect(find.text('Action Test 2'),
-          findsOneWidget); // it should NOT be dismissed
+      await tester.pump(
+        const Duration(milliseconds: 600),
+      ); // wait for exit animation
+      expect(
+        find.text('Action Test 2'),
+        findsOneWidget,
+      ); // it should NOT be dismissed
 
       await tester.pumpAndSettle();
     });
 
-    testWidgets('Very long text in non-scrollable mode applies ellipsis',
-        (WidgetTester tester) async {
+    testWidgets('Very long text in non-scrollable mode applies ellipsis', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestApp(Container()));
 
       final longText = 'A' * 1000;
@@ -495,8 +523,9 @@ void main() {
       await tester.pumpAndSettle();
     });
 
-    testWidgets('Very long text in scrollable mode allows scrolling',
-        (WidgetTester tester) async {
+    testWidgets('Very long text in scrollable mode allows scrolling', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestApp(Container()));
 
       final longText = 'A\n' * 100;
@@ -529,15 +558,13 @@ void main() {
       await tester.pumpAndSettle();
     });
 
-    testWidgets('Progress bar renders correctly based on progressBarWidth',
-        (WidgetTester tester) async {
+    testWidgets('Progress bar renders correctly based on progressBarWidth', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestApp(Container()));
 
       // 1. Line Effect
-      HyperSnackbar.show(
-        title: 'Line Progress',
-        progressBarWidth: 4.0,
-      );
+      HyperSnackbar.show(title: 'Line Progress', progressBarWidth: 4.0);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
 
@@ -547,10 +574,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // 2. Wipe Effect
-      HyperSnackbar.show(
-        title: 'Wipe Progress',
-        progressBarWidth: 0.0,
-      );
+      HyperSnackbar.show(title: 'Wipe Progress', progressBarWidth: 0.0);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
 
@@ -562,28 +586,30 @@ void main() {
     });
 
     testWidgets(
-        'useAdaptiveLoader shows platform-specific loader instead of icon',
-        (WidgetTester tester) async {
-      // Test for non-Cupertino platform (Android by default in test)
-      await tester.pumpWidget(createTestApp(Container()));
+      'useAdaptiveLoader shows platform-specific loader instead of icon',
+      (WidgetTester tester) async {
+        // Test for non-Cupertino platform (Android by default in test)
+        await tester.pumpWidget(createTestApp(Container()));
 
-      HyperSnackbar.show(
-        title: 'Loader Test',
-        icon: const Icon(Icons.star), // should be ignored
-        useAdaptiveLoader: true,
-      );
+        HyperSnackbar.show(
+          title: 'Loader Test',
+          icon: const Icon(Icons.star), // should be ignored
+          useAdaptiveLoader: true,
+        );
 
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 100));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
 
-      expect(find.byIcon(Icons.star), findsNothing);
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byIcon(Icons.star), findsNothing);
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
-      await tester.pumpAndSettle();
-    });
+        await tester.pumpAndSettle();
+      },
+    );
 
-    testWidgets('Convenience methods and animations coverage',
-        (WidgetTester tester) async {
+    testWidgets('Convenience methods and animations coverage', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createTestApp(Container()));
 
       // 1. Test various convenience methods
@@ -596,7 +622,9 @@ void main() {
       HyperSnackbar.show(title: 'Initial', id: 'update_test');
       await tester.pump();
       HyperSnackbar.show(
-          title: 'Updated', id: 'update_test'); // Passes through _tryUpdate
+        title: 'Updated',
+        id: 'update_test',
+      ); // Passes through _tryUpdate
       await tester.pump();
       HyperSnackbar.dismissById('update_test'); // Passes through dismissById
 


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Silently swallowed exceptions during the removal of an `OverlayEntry` in `lib/src/manager.dart`. Specifically, the code was using `catch (_) {}` blocks, which suppressed any errors occurring during overlay cleanup.

### ⚠️ Risk: The potential impact if left unfixed
If errors occur during the removal of an overlay (e.g., if it was already removed or never inserted), they would go unnoticed. This could lead to difficult-to-diagnose state inconsistencies, memory leaks, or UI bugs where overlays are not properly cleaned up, potentially affecting the application's stability and developer experience during testing and production.

### 🛡️ Solution: How the fix addresses the vulnerability
Replaced the empty `catch (_) {}` blocks with `catch (e) { debugPrint('HyperSnackbar: Error removing overlay entry: $e'); }` at all relevant locations:
1. `clearAll` method (line 532)
2. `_mountOverlayIfNeeded` method (line 747)
3. `resetForTest` method (line 786)

This ensures that any cleanup errors are explicitly logged using `debugPrint`, providing necessary visibility for developers without interrupting the application flow.


---
*PR created automatically by Jules for task [668161167404885441](https://jules.google.com/task/668161167404885441) started by @MakiAno*